### PR TITLE
Bedre feilmeldinger

### DIFF
--- a/src/main/kotlin/no/nav/aareg/teknisk_historikk/Feil.kt
+++ b/src/main/kotlin/no/nav/aareg/teknisk_historikk/Feil.kt
@@ -1,13 +1,23 @@
 package no.nav.aareg.teknisk_historikk
 
-enum class Feilkoder(val feilkode: String, val feiltekst: String) {
+enum class Feilkode(val feilkode: String, val feiltekst: String) {
     AAREG_SERVICES_ERROR("AS1", "Feil oppstod ved henting av arbeidsforhold"),
     AAREG_SERVICES_UNAUTHORIZED("AS2", "Feil oppstod ved henting av arbeidsforhold"),
-    AAREG_SERVICES_FORBIDDEN("AS3", "Feil oppstod ved henting av arbeidsforhold"),
     AAREG_SERVICES_MALFORMED("AS4", "Feil oppstod ved henting av arbeidsforhold"),
     AZURE_TOKEN_FAILED("AD1", "Feil oppstod ved henting av arbeidsforhold");
 
     override fun toString(): String {
         return "$feilkode: $feiltekst"
     }
+}
+
+class Feil(val feilkode: Feilkode, cause: Throwable) : Exception(feilkode.toString(), cause) {
+    fun feilrespons() = Feilrespons(feilkode.feilkode, feilkode.feiltekst)
+}
+
+data class Feilrespons(
+    val kode: String,
+    val melding: String
+) {
+    constructor(feilkode: Feilkode) : this(feilkode.feilkode, feilkode.feiltekst)
 }

--- a/src/main/kotlin/no/nav/aareg/teknisk_historikk/Feilmeldinger.kt
+++ b/src/main/kotlin/no/nav/aareg/teknisk_historikk/Feilmeldinger.kt
@@ -1,14 +1,30 @@
 package no.nav.aareg.teknisk_historikk
 
+import no.nav.aareg.teknisk_historikk.aareg_services.AaregServicesForbiddenException
+import no.nav.aareg.teknisk_historikk.models.TjenestefeilResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.ResponseEntity.status
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.client.HttpClientErrorException.Forbidden
 import javax.servlet.http.HttpServletRequest
 
 @ControllerAdvice
 class Feilmeldinger {
+
+    @ExceptionHandler(AaregServicesForbiddenException::class)
+    fun forbiddenHandler(forbidden: Forbidden, httpServletRequest: HttpServletRequest): ResponseEntity<TjenestefeilResponse> {
+        return status(HttpStatus.FORBIDDEN).body(
+            TjenestefeilResponse().apply { meldinger = listOf("Du mangler tilgang til å gjøre oppslag på arbeidstakeren") }
+        )
+    }
+
+    @ExceptionHandler(Feil::class)
+    fun feilhandler(feil: Feil, httpServletRequest: HttpServletRequest): ResponseEntity<Feilrespons> {
+        return status(HttpStatus.INTERNAL_SERVER_ERROR).body(feil.feilrespons())
+    }
+
     @ExceptionHandler(Exception::class)
     fun handler(exception: Throwable, httpServletRequest: HttpServletRequest): ResponseEntity<String> {
         return status(HttpStatus.INTERNAL_SERVER_ERROR).body("En ukjent feil oppstod")


### PR DESCRIPTION
Den viktigste endringen er å håndtere 403 fra
aareg-services. Dette er nå en forventet respons
(enkelte arbeidsforhold kan ikke slås opp på)
og kan ikke lenger resultere i en 500-feil.