### PR TITLE
Opprydning i feltnavn

### DIFF
--- a/src/main/kotlin/no/nav/aareg/teknisk_historikk/aareg_services/AaregServicesKonsument.kt
+++ b/src/main/kotlin/no/nav/aareg/teknisk_historikk/aareg_services/AaregServicesKonsument.kt
@@ -77,9 +77,9 @@ class AaregServicesConsumer(
             contentType = MediaType.APPLICATION_JSON
             set("Nav-Call-Id", appName)
             set(KORRELASJONSID_HEADER, MDC.get(KORRELASJONSID_HEADER))
-            set("Nav-Personident", soekeparametere.arbeidstakerident)
-            if (soekeparametere.arbeidsstedident != null) {
-                set("Nav-Arbeidsstedident", soekeparametere.arbeidsstedident)
+            set("Nav-Personident", soekeparametere.arbeidstaker)
+            if (soekeparametere.arbeidssted != null) {
+                set("Nav-Arbeidsstedident", soekeparametere.arbeidssted)
             }
             if (soekeparametere.opplysningspliktig != null) {
                 set("Nav-Opplysningspliktigident", soekeparametere.opplysningspliktig)

--- a/src/main/kotlin/no/nav/aareg/teknisk_historikk/api/ArbeidsforholdApi.kt
+++ b/src/main/kotlin/no/nav/aareg/teknisk_historikk/api/ArbeidsforholdApi.kt
@@ -19,14 +19,14 @@ import java.util.Optional.ofNullable
 import javax.servlet.http.HttpServletRequest
 
 val EKSEMPEL_SOEK = ObjectMapper().writerFor(Soekeparametere::class.java).writeValueAsString(Soekeparametere().apply {
-    arbeidstakerident = "12345678912"
+    arbeidstaker = "12345678912"
     opplysningspliktig = null
-    arbeidsstedident = null
+    arbeidssted = null
 })
 
-val IKKE_LESBAR_FEILMELDING = "Kunne ikke lese søkeforespørselen. Eksempel på gyldig søk: $EKSEMPEL_SOEK"
-const val ARBEIDSTAKER_ER_PAAKREVD = "arbeidstakerident er et påkrevd felt"
-const val ARBEIDSTAKER_MAA_VAERE_TALL = "arbeidstakerident må kun være tall"
+val IKKE_LESBAR_FEILMELDING = "Kunne ikke lese søkeforespørselen. Eksempel på gyldig json: $EKSEMPEL_SOEK"
+const val ARBEIDSTAKER_ER_PAAKREVD = "arbeidstaker er et påkrevd felt"
+const val ARBEIDSTAKER_MAA_VAERE_TALL = "arbeidstaker må kun være tall"
 const val OPPLYSNINGSPLIKTIG_MAA_VAERE_TALL = "opplysningspliktig må kun være tall"
 const val ARBEIDSSTED_MAA_VAERE_TALL = "arbeidssted må kun være tall"
 
@@ -48,10 +48,10 @@ class ArbeidsforholdApi(
     private fun validerSoekeparametere(soekeparametere: Soekeparametere) {
         val allNumbersMatcher = "\\d+".toRegex()
         val valideringsfeil = listOf(
-            if (soekeparametere.arbeidstakerident == null) ARBEIDSTAKER_ER_PAAKREVD else null,
-            if (soekeparametere.arbeidstakerident?.matches(allNumbersMatcher) != true) ARBEIDSTAKER_MAA_VAERE_TALL else null,
+            if (soekeparametere.arbeidstaker == null) ARBEIDSTAKER_ER_PAAKREVD else null,
+            if (soekeparametere.arbeidstaker?.matches(allNumbersMatcher) != true) ARBEIDSTAKER_MAA_VAERE_TALL else null,
             if (soekeparametere.opplysningspliktig != null && !soekeparametere.opplysningspliktig.matches(allNumbersMatcher)) OPPLYSNINGSPLIKTIG_MAA_VAERE_TALL else null,
-            if (soekeparametere.arbeidsstedident != null && !soekeparametere.arbeidsstedident.matches(allNumbersMatcher)) ARBEIDSSTED_MAA_VAERE_TALL else null
+            if (soekeparametere.arbeidssted != null && !soekeparametere.arbeidssted.matches(allNumbersMatcher)) ARBEIDSSTED_MAA_VAERE_TALL else null
         ).filterNotNull()
 
         if (valideringsfeil.isNotEmpty())

--- a/src/main/resources/static/openapi-spec.yaml
+++ b/src/main/resources/static/openapi-spec.yaml
@@ -81,14 +81,14 @@ components:
     Soekeparametere:
       type: object
       properties:
-        arbeidstakerident:
+        arbeidstaker:
           type: string
-        arbeidsstedident:
+        arbeidssted:
           type: string
         opplysningspliktig:
           type: string
       required:
-        - arbeidstakerident
+        - arbeidstaker
     Person:
       type: object
       description: Identtype som representerer en person. 'type' vil alltid være 'Person'

--- a/src/test/kotlin/no/nav/aareg/teknisk_historikk/api/ArbeidsforholdV1ApiTest.kt
+++ b/src/test/kotlin/no/nav/aareg/teknisk_historikk/api/ArbeidsforholdV1ApiTest.kt
@@ -75,7 +75,7 @@ class ArbeidsforholdV1ApiTest : AaregTekniskHistorikkTest() {
             ENDEPUNKT_URI,
             HttpEntity(gyldigSoekeparameter().apply {
                 opplysningspliktig = "123456"
-                arbeidsstedident = "12345"
+                arbeidssted = "12345"
             }, headerMedAutentisering()),
             FinnTekniskHistorikkForArbeidstaker200Response::class.java
         )
@@ -203,9 +203,9 @@ class ArbeidsforholdV1ApiTest : AaregTekniskHistorikkTest() {
         val result = testRestTemplate.postForEntity(
             ENDEPUNKT_URI,
             HttpEntity(Soekeparametere().apply {
-                arbeidstakerident = "abcd1234"
+                arbeidstaker = "abcd1234"
                 opplysningspliktig = "abcd1234"
-                arbeidsstedident = "abcd1234"
+                arbeidssted = "abcd1234"
             }, headerMedKorrelasjonsId()),
             TjenestefeilResponse::class.java
         )
@@ -267,7 +267,7 @@ fun headerMedKorrelasjonsId() = HttpHeaders().apply {
 }
 
 fun gyldigSoekeparameter() = Soekeparametere().apply {
-    arbeidstakerident = "123456789"
+    arbeidstaker = "123456789"
 }
 
 fun tjenestefeilMedMelding(vararg melding: String) = TjenestefeilResponse().apply {


### PR DESCRIPTION
Feltnavnene var inkonsistente; opplysningspliktig
er en ident, men kun arbeidssted og arbeidstaker
var indikert som "identer" i navnet.
Ettersom speccen allerede forklarer hva feltene
representerer, så fjerner vi begrepet "ident"