### PR TITLE
Korrelasjonsid i tjenestefeilresponser

### DIFF
--- a/src/main/kotlin/no/nav/aareg/teknisk_historikk/Feilmeldinger.kt
+++ b/src/main/kotlin/no/nav/aareg/teknisk_historikk/Feilmeldinger.kt
@@ -20,11 +20,8 @@ class Feilmeldinger {
     private val secureLog = LoggerFactory.getLogger("secureLogger")
 
     @ExceptionHandler(AaregServicesForbiddenException::class)
-    fun forbiddenHandler(forbidden: Forbidden, httpServletRequest: HttpServletRequest): ResponseEntity<TjenestefeilResponse> {
-        return status(HttpStatus.FORBIDDEN).body(
-            TjenestefeilResponse().apply { meldinger = listOf("Du mangler tilgang til å gjøre oppslag på arbeidstakeren") }
-        )
-    }
+    fun forbiddenHandler(forbidden: Forbidden, httpServletRequest: HttpServletRequest) =
+        tjenestefeilRespons(httpServletRequest, HttpStatus.FORBIDDEN, "Du mangler tilgang til å gjøre oppslag på arbeidstakeren")
 
     @ExceptionHandler(Feil::class)
     fun feilhandler(feil: Feil, httpServletRequest: HttpServletRequest): ResponseEntity<Feilrespons> {
@@ -34,6 +31,7 @@ class Feilmeldinger {
     @ExceptionHandler(HttpMediaTypeNotSupportedException::class)
     fun feilMediaType(exception: HttpMediaTypeNotSupportedException, httpServletRequest: HttpServletRequest) =
         tjenestefeilRespons(
+            httpServletRequest,
             HttpStatus.UNSUPPORTED_MEDIA_TYPE,
             "Feil mediatype: ${httpServletRequest.contentType}",
             "Støttede typer: ${exception.supportedMediaTypes.joinToString(", ")}"
@@ -42,6 +40,7 @@ class Feilmeldinger {
     @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
     fun feilRequestType(exception: HttpRequestMethodNotSupportedException, httpServletRequest: HttpServletRequest) =
         tjenestefeilRespons(
+            httpServletRequest,
             HttpStatus.METHOD_NOT_ALLOWED,
             "Http-verb ikke tillatt: ${httpServletRequest.method}",
             "Verb som er støttet: ${exception.supportedHttpMethods?.joinToString(", ")}"
@@ -51,6 +50,6 @@ class Feilmeldinger {
     fun generiskFeil(exception: Throwable, httpServletRequest: HttpServletRequest): ResponseEntity<TjenestefeilResponse> {
         log.error("Uhåndtert feil oppstod. Sjekk sikker log for detaljer")
         secureLog.error("Uhåndtert feil oppstod", exception)
-        return tjenestefeilRespons(HttpStatus.INTERNAL_SERVER_ERROR, "En ukjent feil oppstod")
+        return tjenestefeilRespons(httpServletRequest, HttpStatus.INTERNAL_SERVER_ERROR, "En ukjent feil oppstod")
     }
 }

--- a/src/main/kotlin/no/nav/aareg/teknisk_historikk/RequestHeaderFilter.kt
+++ b/src/main/kotlin/no/nav/aareg/teknisk_historikk/RequestHeaderFilter.kt
@@ -13,8 +13,16 @@ const val KORRELASJONSID_HEADER = "correlation-id"
 @Component
 class RequestHeaderFilter : OncePerRequestFilter() {
     override fun doFilterInternal(req: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
-        MDC.put(KORRELASJONSID_HEADER, req.getHeader(KORRELASJONSID_HEADER) ?: randomUUID().toString())
+        try {
+            val korrelasjonsid = req.getHeader(KORRELASJONSID_HEADER) ?: randomUUID().toString()
 
-        filterChain.doFilter(req, response)
+            MDC.put(KORRELASJONSID_HEADER, korrelasjonsid)
+            req.setAttribute(KORRELASJONSID_HEADER, korrelasjonsid)
+            response.addHeader(KORRELASJONSID_HEADER, korrelasjonsid)
+
+            filterChain.doFilter(req, response)
+        } finally {
+            MDC.remove(KORRELASJONSID_HEADER)
+        }
     }
 }

--- a/src/main/kotlin/no/nav/aareg/teknisk_historikk/Utils.kt
+++ b/src/main/kotlin/no/nav/aareg/teknisk_historikk/Utils.kt
@@ -3,11 +3,13 @@ package no.nav.aareg.teknisk_historikk
 import no.nav.aareg.teknisk_historikk.models.TjenestefeilResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity.status
+import javax.servlet.http.HttpServletRequest
 
-fun tjenestefeilRespons(httpStatus: HttpStatus, vararg feilmeldinger: String) =
-    tjenestefeilRespons(httpStatus, feilmeldinger.asList())
+fun tjenestefeilRespons(httpServletRequest: HttpServletRequest, httpStatus: HttpStatus, vararg feilmeldinger: String) =
+    tjenestefeilRespons(httpServletRequest, httpStatus, feilmeldinger.asList())
 
-fun tjenestefeilRespons(httpStatus: HttpStatus, feilmeldinger: List<String>) =
+fun tjenestefeilRespons(httpServletRequest: HttpServletRequest, httpStatus: HttpStatus, feilmeldinger: List<String>) =
     status(httpStatus).body(TjenestefeilResponse().apply {
+        korrelasjonsid = httpServletRequest.getAttribute(KORRELASJONSID_HEADER) as String
         meldinger = feilmeldinger
     })

--- a/src/main/kotlin/no/nav/aareg/teknisk_historikk/api/ArbeidsforholdApi.kt
+++ b/src/main/kotlin/no/nav/aareg/teknisk_historikk/api/ArbeidsforholdApi.kt
@@ -60,11 +60,11 @@ class ArbeidsforholdApi(
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun ikkeLesbarFeil(exception: HttpMessageNotReadableException, httpServletRequest: HttpServletRequest) =
-        tjenestefeilRespons(HttpStatus.BAD_REQUEST, IKKE_LESBAR_FEILMELDING)
+        tjenestefeilRespons(httpServletRequest, HttpStatus.BAD_REQUEST, IKKE_LESBAR_FEILMELDING)
 
     @ExceptionHandler(Valideringsfeil::class)
     fun ikkeLesbarFeil(exception: Valideringsfeil, httpServletRequest: HttpServletRequest) =
-        tjenestefeilRespons(HttpStatus.BAD_REQUEST, exception.feilmeldinger)
+        tjenestefeilRespons(httpServletRequest, HttpStatus.BAD_REQUEST, exception.feilmeldinger)
 }
 
 class Valideringsfeil(val feilmeldinger: List<String>) : Throwable()

--- a/src/main/resources/static/openapi-spec.yaml
+++ b/src/main/resources/static/openapi-spec.yaml
@@ -232,6 +232,9 @@ components:
     TjenestefeilResponse:
       type: object
       properties:
+        korrelasjonsid:
+          type: string
+          description: Id som kan sendes til Nav for bruk i feilsøk
         meldinger:
           type: array
           description: Liste med informasjon om hva som er feil


### PR DESCRIPTION
Gjør korrelasjonsid mer synlig ved å legge den til i respons-header og payload.